### PR TITLE
Add upcoming spotlight, centralize spotlight rendering, and cache upcoming movies for 12h

### DIFF
--- a/api/src/infrastructure/constants/cacheTtl.ts
+++ b/api/src/infrastructure/constants/cacheTtl.ts
@@ -1,9 +1,11 @@
 /**
  * キャッシュの有効期限（秒単位）
- * - SHORT: リスト系データに使用（discover, now_playing）
+ * - SHORT: リスト系データに使用（discover, now_playing, trending）
+ * - UPCOMING: 公開予定リストに使用（更新頻度が低いため長め）
  * - STANDARD: 詳細・静的データに使用（details, videos, images, scraping, YouTube）
  */
 export const CACHE_TTL = {
   SHORT: 3600,
   STANDARD: 86400,
+  UPCOMING: 43200,
 } as const;

--- a/api/src/infrastructure/repositories/tmdb.repository.ts
+++ b/api/src/infrastructure/repositories/tmdb.repository.ts
@@ -29,7 +29,7 @@ import { IClock } from "../../domain/repositories/clock.service.interface";
 const TMDB_DEFAULTS = {
   REGION: "JP",
   LANGUAGE: "ja",
-  UPCOMING_MONTHS: 2,
+  UPCOMING_MONTHS: 6,
   FILTERS: {
     MIN_VOTE_COUNT: 10,
     RECENT_VOTE_COUNT: 1000,
@@ -131,7 +131,25 @@ export class TmdbRepository implements ITmdbRepository {
       ...periodParams,
     };
 
-    return this.discoverMovies(params);
+    const rawData = await this.cache.getOrSet(
+      `tmdb:upcoming:raw:${JSON.stringify(params)}`,
+      async () => {
+        const response = await this.api.get<PaginatedResponse<MovieResponse>>(
+          "/discover/movie",
+          { params },
+        );
+        return response.data;
+      },
+      CACHE_TTL.UPCOMING,
+    );
+
+    return {
+      movies: rawData.results.map((movie) =>
+        MovieFactory.createFromApiResponse(movie),
+      ),
+      currentPage: rawData.page,
+      totalPages: rawData.total_pages,
+    };
   }
 
   /** 現在上映中の映画を取得する */

--- a/frontend/src/constants/config.ts
+++ b/frontend/src/constants/config.ts
@@ -51,4 +51,6 @@ export const GENRE_NAMES: Record<number, string> = {
 export const QUERY_CONFIG = {
   /** デフォルトのキャッシュ生存時間: 1時間 */
   STALE_TIME_DEFAULT: 1000 * 60 * 60,
+  /** 公開予定のキャッシュ生存時間: 12時間 */
+  STALE_TIME_UPCOMING: 1000 * 60 * 60 * 12,
 } as const;

--- a/frontend/src/features/home/components/NowPlayingSpotlightSection.tsx
+++ b/frontend/src/features/home/components/NowPlayingSpotlightSection.tsx
@@ -1,0 +1,42 @@
+import SpotlightSection from './SpotlightSection';
+import SpotlightCard from './SpotlightCard';
+import NowPlayingCard from './NowPlayingCard';
+import { useInfiniteMovieList } from '@/hooks/useMovies';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { PaginatedResponse } from '@/types/api/response';
+import { Movie } from '@/types/api/dto';
+
+type Props = {
+  title: string;
+  subtitle?: string;
+  initialData?: PaginatedResponse<Movie>;
+};
+
+const NowPlayingSpotlightSection = ({ title, subtitle, initialData }: Props) => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteMovieList(
+    'now_playing',
+    initialData,
+  );
+
+  const observerRef = useInfiniteScroll(hasNextPage, isFetchingNextPage, fetchNextPage, {
+    rootMargin: '0px 800px 0px 0px',
+  });
+
+  const items = data ? data.pages.flatMap((page) => page.movies) : [];
+
+  return (
+    <SpotlightSection<Movie>
+      title={title}
+      subtitle={subtitle}
+      type="now_playing"
+      items={items}
+      observerRef={observerRef}
+      renderSpotlightItem={(movie) => <SpotlightCard movie={movie} variant="now_playing" />}
+      renderRemainingItem={(movie) => (
+        <NowPlayingCard movie={movie} className="basis-[32%] xl:basis-[22%] 2xl:basis-[12%]" />
+      )}
+    />
+  );
+};
+
+export default NowPlayingSpotlightSection;

--- a/frontend/src/features/home/components/SpotlightSection.tsx
+++ b/frontend/src/features/home/components/SpotlightSection.tsx
@@ -3,14 +3,10 @@ import { Autoplay, Pagination, Navigation, EffectFade } from 'swiper/modules';
 import { Link } from 'react-router-dom';
 import { ChevronRightIcon } from '@heroicons/react/24/solid';
 
-import React, { ReactNode, useEffect } from 'react';
+import React, { ReactNode } from 'react';
 import SectionHeader from './SectionHeader';
 import HorizontalScrollContainer from '@/components/HorizontalScrollContainer';
 import { APP_PATHS } from '@shared/constants/routes';
-import { useInfiniteMovieList } from '@/hooks/useMovies';
-import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
-import { PaginatedResponse } from '@/types/api/response';
-import { Movie, UpcomingMovie } from '@/types/api/dto';
 
 import 'swiper/css';
 import 'swiper/css/effect-fade';
@@ -24,56 +20,21 @@ type Props<T> = {
   title: string;
   subtitle?: string;
   type: string;
-  initialData?: PaginatedResponse<T>;
+  items: T[];
   renderSpotlightItem: (item: T) => ReactNode;
   renderRemainingItem: (item: T) => ReactNode;
+  observerRef?: React.RefObject<HTMLDivElement | null>;
 };
 
 /**
- * スポットライトセクション
+ * スポットライトセクション（表示専用）
  *
  * 先頭N件を大型 `SpotlightCard` のスワイパーで表示し、
  * 残りのアイテムを横スクロール可能なカード列として表示する純粋なレイアウトセクション。
- *
- * @param title - セクションタイトル
- * @param subtitle - サブテキスト
- * @param type - カテゴリタイプ
- * @param items - 表示するアイテムのリスト
- * @param renderSpotlightItem - スワイパー内のアイテムを描画する関数
- * @param renderRemainingItem - 横スクロール内のアイテムを描画する関数
  */
 const SpotlightSection = <T extends { id: number | string }>(props: Props<T>) => {
-  const { title, subtitle, type, initialData, renderSpotlightItem, renderRemainingItem } = props;
-
-  const {
-    data: infiniteData,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useInfiniteMovieList(
-    type,
-    initialData as unknown as PaginatedResponse<Movie | UpcomingMovie>,
-  );
-
-  const observerRef = useInfiniteScroll(
-    hasNextPage,
-    isFetchingNextPage,
-    fetchNextPage,
-    { rootMargin: '0px 800px 0px 0px' }, // 横方向の先読みマージン
-  );
-
-  // initialDataがある場合、マウント時に次ページをバックグラウンドでプリフェッチ
-  // 横スクロールはコンテンツ到達が速いため、番兵発火前に先行ロードを行う
-  useEffect(() => {
-    if (initialData && hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const items = infiniteData
-    ? (infiniteData.pages.flatMap((page) => page.movies) as unknown as T[])
-    : [];
+  const { title, subtitle, type, items, renderSpotlightItem, renderRemainingItem, observerRef } =
+    props;
 
   if (!items || items.length === 0) return null;
 
@@ -118,7 +79,7 @@ const SpotlightSection = <T extends { id: number | string }>(props: Props<T>) =>
               <React.Fragment key={item.id}>{renderRemainingItem(item)}</React.Fragment>
             ))}
             {/* 番兵（インフィニットスクローラー） */}
-            <div ref={observerRef} className="w-10 flex-shrink-0" />
+            {observerRef && <div ref={observerRef} className="w-10 flex-shrink-0" />}
           </HorizontalScrollContainer>
         </div>
       )}

--- a/frontend/src/features/home/components/UpcomingSpotlightSection.tsx
+++ b/frontend/src/features/home/components/UpcomingSpotlightSection.tsx
@@ -1,0 +1,32 @@
+import SpotlightSection from './SpotlightSection';
+import SpotlightCard from './SpotlightCard';
+import UpcomingMovieCard from './UpcomingMovieCard';
+import { useUpcomingSpotlightMovies } from '@/hooks/useMovies';
+import { PaginatedResponse } from '@/types/api/response';
+import { UpcomingMovie } from '@/types/api/dto';
+
+type Props = {
+  title: string;
+  subtitle?: string;
+  initialData?: PaginatedResponse<UpcomingMovie>;
+};
+
+const UpcomingSpotlightSection = ({ title, subtitle, initialData }: Props) => {
+  const { data } = useUpcomingSpotlightMovies(initialData);
+  const items = data ?? [];
+
+  return (
+    <SpotlightSection<UpcomingMovie>
+      title={title}
+      subtitle={subtitle}
+      type="upcoming"
+      items={items}
+      renderSpotlightItem={(movie) => <SpotlightCard movie={movie} variant="upcoming" />}
+      renderRemainingItem={(movie) => (
+        <UpcomingMovieCard movie={movie} className="basis-[32%] xl:basis-[22%] 2xl:basis-[12%]" />
+      )}
+    />
+  );
+};
+
+export default UpcomingSpotlightSection;

--- a/frontend/src/features/home/index.tsx
+++ b/frontend/src/features/home/index.tsx
@@ -2,10 +2,8 @@ import { motion, useAnimation } from 'framer-motion';
 import { useEffect } from 'react';
 import { useHomePage } from '@/hooks/useMovies';
 import HeroSwiper from './components/HeroSwiper';
-import SpotlightSection from './components/SpotlightSection';
-import SpotlightCard from './components/SpotlightCard';
-import UpcomingMovieCard from './components/UpcomingMovieCard';
-import NowPlayingCard from './components/NowPlayingCard';
+import UpcomingSpotlightSection from './components/UpcomingSpotlightSection';
+import NowPlayingSpotlightSection from './components/NowPlayingSpotlightSection';
 import TrendingSection from './components/TrendingSection';
 import RecentlyAddedSection from './components/RecentlyAddedSection';
 
@@ -97,35 +95,19 @@ function HomePage() {
       <div className="lg:p-6 xl:p-12 2xl:p-20 2xl:pb-0">
         {/* ✦ スポットライト: 公開予定 */}
         <motion.div variants={sectionVariants}>
-          <SpotlightSection
+          <UpcomingSpotlightSection
             title="公開予定"
             subtitle="まもなく公開される注目作品"
-            type="upcoming"
             initialData={data.upcoming}
-            renderSpotlightItem={(movie) => <SpotlightCard movie={movie} variant="upcoming" />}
-            renderRemainingItem={(movie) => (
-              <UpcomingMovieCard
-                movie={movie}
-                className="basis-[32%] xl:basis-[22%] 2xl:basis-[12%]"
-              /> // この２つのカード群は強調する
-            )}
           />
         </motion.div>
 
         {/* ✦ スポットライト: 公開中 */}
         <motion.div variants={sectionVariants}>
-          <SpotlightSection
+          <NowPlayingSpotlightSection
             title="公開中の映画"
             subtitle="今、劇場で観られる映画"
-            type="now_playing"
             initialData={data.nowPlaying}
-            renderSpotlightItem={(movie) => <SpotlightCard movie={movie} variant="now_playing" />}
-            renderRemainingItem={(movie) => (
-              <NowPlayingCard
-                movie={movie}
-                className="basis-[32%] xl:basis-[22%] 2xl:basis-[12%]"
-              /> // この２つのカード群は強調する
-            )}
           />
         </motion.div>
 

--- a/frontend/src/hooks/useMovies.ts
+++ b/frontend/src/hooks/useMovies.ts
@@ -27,6 +27,8 @@ const movieKeys = {
   ids: (ids: number[]) => [...movieKeys.all, 'ids', ids.join(',')] as const,
 };
 
+export type InfiniteMovieListType = 'trending' | 'now_playing' | 'recently_added';
+
 export const useFullMovieData = (movieId: number) => {
   return useQuery({
     queryKey: movieKeys.detail(movieId),
@@ -89,7 +91,19 @@ export const useUpcomingMovies = () => {
       const res = await fetchUpcomingMovies();
       return res.movies;
     },
-    staleTime: QUERY_CONFIG.STALE_TIME_DEFAULT, // オプション：キャッシュ時間を設定(1時間)
+    staleTime: QUERY_CONFIG.STALE_TIME_UPCOMING,
+  });
+};
+
+export const useUpcomingSpotlightMovies = (initialData?: PaginatedResponse<UpcomingMovie>) => {
+  return useQuery<UpcomingMovie[]>({
+    queryKey: movieKeys.list('upcoming_spotlight'),
+    queryFn: async () => {
+      const res = await fetchUpcomingMovies(1);
+      return res.movies;
+    },
+    initialData: initialData?.movies,
+    staleTime: QUERY_CONFIG.STALE_TIME_UPCOMING,
   });
 };
 
@@ -107,19 +121,18 @@ export const useTrendingMovies = () => {
 
 /**
  * 【汎用ファサード】リストのカテゴリ(type)を受け取り、無限スクロール用に正規化されたページネーションデータを返す
- * @param type カテゴリ名 ('upcoming', 'now_playing', etc.)
+ * @param type カテゴリ名 ('trending' | 'now_playing' | 'recently_added')
  * @param initialData 初期レンダリング用のページネーションデータ（キャッシュのHydration用）
  */
 export const useInfiniteMovieList = (
-  type: string | undefined,
-  initialData?: PaginatedResponse<Movie | UpcomingMovie>,
+  type: InfiniteMovieListType,
+  initialData?: PaginatedResponse<Movie>,
 ) => {
   return useInfiniteQuery({
-    queryKey: movieKeys.infiniteList(type || 'unknown'),
+    queryKey: movieKeys.infiniteList(type),
     queryFn: async ({ pageParam = 1 }) => {
       if (type === 'trending') return fetchTrendingMovies(pageParam);
       if (type === 'now_playing') return fetchNowPlayingMovies(pageParam);
-      if (type === 'upcoming') return fetchUpcomingMovies(pageParam);
       if (type === 'recently_added') {
         const res = await fetchMovieList(pageParam);
         return res.recently_added;
@@ -137,7 +150,6 @@ export const useInfiniteMovieList = (
         }
       : undefined,
     staleTime: QUERY_CONFIG.STALE_TIME_DEFAULT,
-    enabled: !!type,
   });
 };
 


### PR DESCRIPTION
### Motivation
- Provide a dedicated, cache-friendly spotlight for upcoming movies and reduce duplicate data fetching across spotlight UI components.
- Make `SpotlightSection` a pure presentation component that accepts prepared items and an optional scroll observer so data/loading concerns move to hooks.
- Increase the upcoming discovery window and cache lifetime to surface more future releases without frequent TMDB calls.

### Description
- Added a new cache TTL `CACHE_TTL.UPCOMING = 43200` (12 hours) and documented its purpose in `cacheTtl.ts` and added `UPC O MING` comment. 
- Increased TMDB upcoming search window from 2 to 6 months by changing `TMDB_DEFAULTS.UPCOMING_MONTHS` in `tmdb.repository.ts` and implemented server-side caching for `findUpcomingMovies` using the new `CACHE_TTL.UPCOMING` key.
- Refactored `SpotlightSection` to be a display-only component that accepts `items` and optional `observerRef` and removed its internal infinite-fetch logic, effect and prefetch behavior.
- Introduced two new UI components `UpcomingSpotlightSection` and `NowPlayingSpotlightSection` and updated the home page to use them for their respective sections.
- Updated hooks in `useMovies.ts`: added `InfiniteMovieListType` type, set `useUpcomingMovies` and new `useUpcomingSpotlightMovies` to use `QUERY_CONFIG.STALE_TIME_UPCOMING`, and simplified `useInfiniteMovieList` to support `trending`, `now_playing`, and `recently_added` while removing the `upcoming` branch.
- Exposed a new frontend constant `QUERY_CONFIG.STALE_TIME_UPCOMING` (12 hours) in `config.ts`.

### Testing
- Ran frontend type-check and build (`yarn build` / `npm run build`) which completed successfully. 
- Ran frontend unit and integration tests (`yarn test` / `npm test`) and all tests passed. 
- Ran backend TypeScript checks and server unit tests which passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df72cf093c832a855ef294309988df)